### PR TITLE
fix: make license args values UPPER case

### DIFF
--- a/src/templates/license.rs
+++ b/src/templates/license.rs
@@ -8,6 +8,7 @@ enum Repr {
 macro_rules! BuiltinLicense {
     ($( $path:literal as $Struct:ident # $doc:literal ),* $(,)?) => {
         #[derive(Clone, clap::ValueEnum)]
+        #[value(rename_all = "UPPER")]
         pub enum BuiltinLicense {
             $(
                 #[doc = $doc]


### PR DESCRIPTION
- before
```
$ pyinit --help
CLI tool to create Python library scaffolding

Usage: pyinit [OPTIONS]

Options:
  -n <NAME>
          Library name

  -d <DESCRIPTION>
          Library description

  -a <AUTHOR>
          Library author's name"

  -l <LICENSE>
          License type

          Possible values:
          - apache: Apache-2.0 license
          - bsd2:   BSD 2-Clause license
          - bsd3:   BSD 3-Clause license
          - cc0:    CC0-1.0 license
          - epl:    EPL-2.0 license
          - gpl:    GPL-3.0 license
          - mit:    MIT license
          - mpl:    MPL-2.0 license

  -h, --help
          Print help (see a summary with '-h')

  -V, --version
          Print version
```
- after
```
$ pyiniy --help
CLI tool to create Python library scaffolding

Usage: pyinit [OPTIONS]

Options:
  -n <NAME>
          Library name

  -d <DESCRIPTION>
          Library description

  -a <AUTHOR>
          Library author's name

  -l <LICENSE>
          License type

          Possible values:
          - APACHE: Apache-2.0 license
          - BSD2:   BSD 2-Clause license
          - BSD3:   BSD 3-Clause license
          - CC0:    CC0-1.0 license
          - EPL:    EPL-2.0 license
          - GPL:    GPL-3.0 license
          - MIT:    MIT license
          - MPL:    MPL-2.0 license

  -h, --help
          Print help (see a summary with '-h')

  -V, --version
          Print version
```