### PR TITLE
fix: `BuiltinLicense` rename_all: "UPPER" -> "verbatim"

### DIFF
--- a/src/templates/license.rs
+++ b/src/templates/license.rs
@@ -8,7 +8,7 @@ enum Repr {
 macro_rules! BuiltinLicense {
     ($( $path:literal as $Struct:ident # $doc:literal ),* $(,)?) => {
         #[derive(Clone, clap::ValueEnum)]
-        #[value(rename_all = "UPPER")]
+        #[value(rename_all = "verbatim")]
         pub enum BuiltinLicense {
             $(
                 #[doc = $doc]


### PR DESCRIPTION
- before
```
  -l <LICENSE>
          License type

          Possible values:
          - APACHE: Apache-2.0 license
          - BSD2:   BSD 2-Clause license
          - BSD3:   BSD 3-Clause license
          - CC0:    CC0-1.0 license
          - EPL:    EPL-2.0 license
          - GPL:    GPL-3.0 license
          - MIT:    MIT license
          - MPL:    MPL-2.0 license
```

- after
```
  -l <LICENSE>
          License type

          Possible values:
          - Apache: Apache-2.0 license
          - BSD2:   BSD 2-Clause license
          - BSD3:   BSD 3-Clause license
          - CC0:    CC0-1.0 license
          - EPL:    EPL-2.0 license
          - GPL:    GPL-3.0 license
          - MIT:    MIT license
          - MPL:    MPL-2.0 license
```